### PR TITLE
fix(deploy): Stop existing services before deploying

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -262,6 +262,13 @@ jobs:
         name: proxy-binary
         path: /tmp/prod-deployment
 
+    - name: Stop existing services
+      run: |
+        sudo systemctl stop wake-on-lan.service || true
+        sudo systemctl stop proxy.service || true
+        echo "Attempted to stop existing services."
+      continue-on-error: true
+
     - name: Deploy Proxy Service
       run: |
         # This is where you would place the proxy binary and its systemd service


### PR DESCRIPTION
This commit fixes a "Text file busy" error that occurred during the production deployment. The error was caused by the workflow attempting to overwrite the `wol-server` executable while it was still running as part of the `wake-on-lan.service`.

A new step, "Stop existing services," has been added to the beginning of the `deploy` job. This step explicitly stops both the `wake-on-lan.service` and the `proxy.service` before any file operations occur. The use of `|| true` and `continue-on-error: true` ensures that the workflow does not fail if the services are not present on the first run.