### PR TITLE
fix(deploy): Add execute permission to proxy server binary

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -274,6 +274,7 @@ jobs:
         # This is where you would place the proxy binary and its systemd service
         sudo mkdir -p /opt/wol-proxy
         sudo cp /tmp/prod-deployment/proxy-server /opt/wol-proxy/
+        sudo chmod +x /opt/wol-proxy/proxy-server
         sudo cp proxy.service /etc/systemd/system/
         sudo systemctl daemon-reload
         sudo systemctl enable --now proxy.service


### PR DESCRIPTION
This commit fixes a `status=203/EXEC` error from systemd when trying to start the proxy service. The error was caused by the proxy server binary (`/opt/wol-proxy/proxy-server`) not having execute permissions after being copied into place.

A `sudo chmod +x /opt/wol-proxy/proxy-server` command has been added to the "Deploy Proxy Service" step in the `deploy` job to ensure the binary is executable.